### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/hardware/confocal_scanner_dummy.py
+++ b/hardware/confocal_scanner_dummy.py
@@ -229,7 +229,7 @@ class ConfocalScannerDummy(Base, ConfocalScannerInterface):
         @return int: error code (0:OK, -1:error)
         """
 
-        if clock_frequency != None:
+        if clock_frequency is not None:
             self._clock_frequency = float(clock_frequency)
 
         self.log.warning('ConfocalScannerDummy>set_up_scanner_clock')

--- a/hardware/microwave/mw_source_anritsu70GHz.py
+++ b/hardware/microwave/mw_source_anritsu70GHz.py
@@ -173,12 +173,12 @@ class MicrowaveAnritsu70GHz(Base, MicrowaveInterface):
         """
         error = 0
         print("set cw")
-        if freq != None:
+        if freq is not None:
             error = self.set_frequency(freq)
         else:
             return -1
 
-        if power != None:
+        if power is not None:
             error = self.set_power(power)
         else:
             return -1

--- a/hardware/microwave/mw_source_gigatronics.py
+++ b/hardware/microwave/mw_source_gigatronics.py
@@ -121,7 +121,7 @@ class MicrowaveGigatronics(Base, MicrowaveInterface):
 
         @return int: error code (0:OK, -1:error)
         """
-        if power != None:
+        if power is not None:
             self._gpib_connection.write(':POW {:f} DBM'.format(power))
             return 0
         else:
@@ -144,7 +144,7 @@ class MicrowaveGigatronics(Base, MicrowaveInterface):
 
         @return int: error code (0:OK, -1:error)
         """
-        if freq != None:
+        if freq is not None:
             self._gpib_connection.write(':FREQ {:e}'.format(freq))
             return 0
         else:
@@ -165,11 +165,11 @@ class MicrowaveGigatronics(Base, MicrowaveInterface):
         error = 0
         self._gpib_connection.write(':MODE CW')
 
-        if freq != None:
+        if freq is not None:
             error = self.set_frequency(freq)
         else:
             return -1
-        if power != None:
+        if power is not None:
             error = self.set_power(power)
         else:
             return -1

--- a/hardware/microwave/mw_source_smiq.py
+++ b/hardware/microwave/mw_source_smiq.py
@@ -183,7 +183,7 @@ class MicrowaveSmiq(Base, MicrowaveInterface):
 
         @return int: error code (0:OK, -1:error)
         """
-        if power != None:
+        if power is not None:
             self._gpib_connection.write(':POW {:f}'.format(power))
             return 0
         else:
@@ -203,7 +203,7 @@ class MicrowaveSmiq(Base, MicrowaveInterface):
 
         @return int: error code (0:OK, -1:error)
         """
-        if freq != None:
+        if freq is not None:
             self._gpib_connection.write(':FREQ {:e}'.format(freq))
             return 0
         else:

--- a/hardware/microwave/mw_source_smr20.py
+++ b/hardware/microwave/mw_source_smr20.py
@@ -188,10 +188,10 @@ class MicrowaveSMR20(Base, MicrowaveInterface):
 
         self._gpib_connection.write(':FREQ:MODE CW')
 
-        if freq != None:
+        if freq is not None:
             self.set_frequency(freq)
 
-        if power != None:
+        if power is not None:
             self.set_power(power)
 
         self.on()

--- a/hardware/motor/motor_stage_pi.py
+++ b/hardware/motor/motor_stage_pi.py
@@ -419,16 +419,16 @@ class MotorStagePI(Base, MotorInterface):
         """
         param_dict = {}
         try:
-            if param_list != None and 'x' in param_list or param_list == None:
+            if param_list is not None and 'x' in param_list or param_list is None:
                 x_value = self._internal_get_pos('x')
                 param_dict['x'] = x_value
-            if param_list != None and 'y' in param_list or param_list == None:
+            if param_list is not None and 'y' in param_list or param_list is None:
                 y_value = self.internal_get_pos('y')
                 param_dict['y'] = y_value
-            if param_list != None and 'z' in param_list or param_list == None:
+            if param_list is not None and 'z' in param_list or param_list is None:
                 z_value = self.internal_get_pos('z')
                 param_dict['z'] = z_value
-            if param_list != None and 'phi' in param_list or param_list == None:
+            if param_list is not None and 'phi' in param_list or param_list is None:
                 phi_temp = self._ask_rot([1,60,0])
                 phi_value = phi_temp * self._MicroStepSize
                 param_dict['phi'] = phi_value
@@ -463,19 +463,19 @@ class MotorStagePI(Base, MotorInterface):
         constraints = self.get_constraints()
         param_dict = {}
         try:
-            if param_list != None and 'x' in param_list or param_list == None:
+            if param_list is not None and 'x' in param_list or param_list is None:
                 x_status = self._serial_connection_xyz.ask(constraints['x']['ID']+'TS')[8:]
                 time.sleep(0.1)
                 param_dict['x'] = x_status
-            if param_list != None and 'y' in param_list or param_list == None:
+            if param_list is not None and 'y' in param_list or param_list is None:
                 y_status = self._serial_connection_xyz.ask(constraints['y']['ID']+'TS')[8:]
                 time.sleep(0.1)
                 param_dict['y'] = y_status
-            if param_list != None and 'z' in param_list or param_list == None:
+            if param_list is not None and 'z' in param_list or param_list is None:
                 z_status = self._serial_connection_xyz.ask(constraints['z']['ID']+'TS')[8:]
                 time.sleep(0.1)
                 param_dict['z'] = z_status
-            if param_list != None and 'phi' in param_list or param_list == None:
+            if param_list is not None and 'phi' in param_list or param_list is None:
                 phi_status = self._ask_rot([1,54,0])
                 param_dict['phi'] = phi_status
             return param_dict
@@ -499,15 +499,15 @@ class MotorStagePI(Base, MotorInterface):
         """
         #TODO: implement calibration x, y and z
         try:
-            if param_list != None and set(['x','y','z']) <= set(param_list) or param_list == None:
+            if param_list is not None and set(['x','y','z']) <= set(param_list) or param_list is None:
                 self._calibrate_xyz()
-            if param_list != None and 'x' in param_list or param_list == None:
+            if param_list is not None and 'x' in param_list or param_list is None:
                 self._calibrate_axis('x')
-            if param_list != None and 'y' in param_list or param_list == None:
+            if param_list is not None and 'y' in param_list or param_list is None:
                 self._calibrate_axis('y')
-            if param_list != None and 'z' in param_list or param_list == None:
+            if param_list is not None and 'z' in param_list or param_list is None:
                 self._calibrate_axis('z')
-            if param_list != None and 'phi' in param_list or param_list == None:
+            if param_list is not None and 'phi' in param_list or param_list is None:
                 self._calibrate_rot()
             return 0
         except:
@@ -623,16 +623,16 @@ class MotorStagePI(Base, MotorInterface):
         constraints = self.get_constraints()
         param_dict = {}
         try:
-            if param_list != None and 'x' in param_list or param_list == None:
+            if param_list is not None and 'x' in param_list or param_list is None:
                 x_vel = int(self._serial_connection_xyz.ask(constraints['x']['ID']+'TY')[8:])
                 param_dict['x'] = x_vel/10000.
-            if param_list != None and 'y' in param_list or param_list == None:
+            if param_list is not None and 'y' in param_list or param_list is None:
                 y_vel = int(self._serial_connection_xyz.ask(constraints['y']['ID']+'TY')[8:])
                 param_dict['y'] = y_vel/10000.
-            if param_list != None and 'z' in param_list or param_list == None:
+            if param_list is not None and 'z' in param_list or param_list is None:
                 z_vel = int(self._serial_connection_xyz.ask(constraints['z']['ID']+'TY')[8:])
                 param_dict['z'] = z_vel/10000.
-            if param_list != None and 'phi' in param_list or param_list == None:
+            if param_list is not None and 'phi' in param_list or param_list is None:
                 data = self._ask_rot([1,53,42])
                 phi_vel = self._data_to_speed_rot(data)
                 param_dict['phi'] = phi_vel

--- a/hardware/odmr_counter_dummy.py
+++ b/hardware/odmr_counter_dummy.py
@@ -84,7 +84,7 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
         @return int: error code (0:OK, -1:error)
         """
 
-        if clock_frequency != None:
+        if clock_frequency is not None:
             self._clock_frequency = float(clock_frequency)
 
         self.log.warning('ODMRCounterDummy>set_up_odmr_clock')
@@ -108,7 +108,7 @@ class ODMRCounterDummy(Base, ODMRCounterInterface):
 
         self.log.warning('ODMRCounterDummy>set_up_odmr')
 
-        if self.getState() == 'locked' or self._scanner_counter_daq_task != None:
+        if self.getState() == 'locked' or self._scanner_counter_daq_task is not None:
             self.log.error('Another odmr is already running, close this one '
                     'first.')
             return -1

--- a/logic/interfuse/mw_differential_scanner.py
+++ b/logic/interfuse/mw_differential_scanner.py
@@ -211,7 +211,7 @@ class ConfocalScannerInterfaceDummy(Base, ConfocalScannerInterface):
         @return int: error code (0:OK, -1:error)
         """
 
-        if clock_frequency != None:
+        if clock_frequency is not None:
             self._clock_frequency = float(clock_frequency)
 
         self.log.warning('ConfocalScannerInterfaceDummy>set_up_scanner_clock')

--- a/logic/measurement_simulator/polarisation_dependence_sim.py
+++ b/logic/measurement_simulator/polarisation_dependence_sim.py
@@ -116,7 +116,7 @@ class PolarizationDependenceSim(Base, SlowCounterInterface, MotorInterface):
     def move_rel(self, axis=None, distance=None):
         """ Move the polarisation angle by relative degrees
         """
-        if distance == None:
+        if distance is None:
             #TODO warning
             pass
 
@@ -135,7 +135,7 @@ class PolarizationDependenceSim(Base, SlowCounterInterface, MotorInterface):
     def move_abs(self, axis=None, position=None):
         """ Move the polarisation angle to absolute degrees
         """
-        if position == None:
+        if position is None:
             #TODO warning
             pass
         self.destination = position

--- a/logic/optimizer_logic.py
+++ b/logic/optimizer_logic.py
@@ -579,9 +579,9 @@ class OptimizerLogic(GenericLogic):
 
     def set_position(self, tag, x=None, y=None, z=None, a=None):
 
-        if x != None:
+        if x is not None:
             self._current_x = x
-        if y != None:
+        if y is not None:
             self._current_y = y
-        if z != None:
+        if z is not None:
             self._current_z = z


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:drogenlied:qudi?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:drogenlied:qudi?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
