### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/core/manager.py
+++ b/core/manager.py
@@ -520,7 +520,7 @@ class Manager(QtCore.QObject):
 
         # FIXME: Check if the class we just obtained has the right inheritance
         if not issubclass(modclass, Base):
-            raise Exception('Bad inheritance, for instance %s from %s.%s.' % (
+            raise Exception('Bad inheritance, for instance {0!s} from {1!s}.{2!s}.'.format(
                 instanceName, baseName, className))
 
         # Create object from class

--- a/gui/manager/errordialog.py
+++ b/gui/manager/errordialog.py
@@ -134,8 +134,8 @@ class ErrorDialog(QtWidgets.QDialog):
             self.messages.append(msg)
             self.nextBtn.show()
             self.nextBtn.setEnabled(True)
-            self.nextBtn.setText('Show next error (%d more)' %
-                                 len(self.messages))
+            self.nextBtn.setText('Show next error ({0:d} more)'.format(
+                                 len(self.messages)))
         else:
             w = QtWidgets.QApplication.activeWindow()
             self.nextBtn.hide()
@@ -193,7 +193,7 @@ class ErrorDialog(QtWidgets.QDialog):
         """ Shows the next error message popup.
         """
         self.msgLabel.setText(self.messages.pop(0))
-        self.nextBtn.setText('Show next error (%d more)' % len(self.messages))
+        self.nextBtn.setText('Show next error ({0:d} more)'.format(len(self.messages)))
         if len(self.messages) == 0:
             self.nextBtn.setEnabled(False)
 

--- a/hardware/awg/tektronix_awg5002c.py
+++ b/hardware/awg/tektronix_awg5002c.py
@@ -1248,7 +1248,7 @@ class AWG5002C(Base, PulserInterface):
                    'E' : 'ENH' ,
                    'S' : 'SEQ'
                   }
-        self.tell('AWGC:RMOD %s\n' % look_up[mode.upper()])
+        self.tell('AWGC:RMOD {0!s}\n'.format(look_up[mode.upper()]))
 
 
     def get_sequencer_mode(self,output_as_int=False):

--- a/hardware/awg/tektronix_awg70k.py
+++ b/hardware/awg/tektronix_awg70k.py
@@ -398,9 +398,9 @@ class AWG70K(Base, PulserInterface):
         for asset in filename:
             file_path  = os.path.join(self.ftp_root_directory, self.asset_directory, asset)
             if asset.endswith('.mat'):
-                self.tell('MMEM:OPEN:SASS:WAV "%s"\n' % file_path)
+                self.tell('MMEM:OPEN:SASS:WAV "{0!s}"\n'.format(file_path))
             else:
-                self.tell('MMEM:OPEN "%s"\n' % file_path)
+                self.tell('MMEM:OPEN "{0!s}"\n'.format(file_path))
             self.ask('*OPC?\n')
         self.soc.settimeout(timeout)
 
@@ -409,16 +409,16 @@ class AWG70K(Base, PulserInterface):
             for asset in filename:
                 # load waveforms into channels
                 name = asset_name + '_ch1'
-                self.tell('SOUR1:CASS:WAV "%s"\n' % name)
+                self.tell('SOUR1:CASS:WAV "{0!s}"\n'.format(name))
                 name = asset_name + '_ch2'
-                self.tell('SOUR2:CASS:WAV "%s"\n' % name)
+                self.tell('SOUR2:CASS:WAV "{0!s}"\n'.format(name))
                 self.current_loaded_asset = asset_name
                 # self.soc.settimeout(3)
         else:
             for channel in load_dict:
                 # load waveforms into channels
                 name = load_dict[channel]
-                self.tell('SOUR'+str(channel)+':CASS:WAV "%s"\n' % name)
+                self.tell('SOUR'+str(channel)+':CASS:WAV "{0!s}"\n'.format(name))
             self.current_loaded_asset = asset_name
 
         return 0
@@ -492,7 +492,7 @@ class AWG70K(Base, PulserInterface):
 
         @return foat: the sample rate returned from the device (-1:error)
         """
-        self.tell('CLOCK:SRATE %.4G\n' % sample_rate)
+        self.tell('CLOCK:SRATE {0:.4G}\n'.format(sample_rate))
         time.sleep(3)
         return_rate = float(self.ask('CLOCK:SRATE?\n'))
         self.sample_rate = return_rate

--- a/hardware/awg/tektronix_awg7122c.py
+++ b/hardware/awg/tektronix_awg7122c.py
@@ -439,7 +439,7 @@ class AWG7122C(Base, PulserInterface):
             file_name = asset_name + '.seq'
 
             # self.tell('MMEMORY:IMPORT "{0}","{1}",SEQ \n'.format(asset_name , asset_name + '.seq'))
-            self.tell('SOUR1:FUNC:USER "%s/%s"\n' % (path, file_name))
+            self.tell('SOUR1:FUNC:USER "{0!s}/{1!s}"\n'.format(path, file_name))
             # self.tell('SOUR1:FUNC:USER "{0}/{1}"\n'.format(path, file_name))
             # set the AWG to the event jump mode:
             self.tell('AWGCONTROL:EVENT:JMODE EJUMP')
@@ -1322,7 +1322,7 @@ class AWG7122C(Base, PulserInterface):
                    'E': 'ENH',
                    'S': 'SEQ'
                    }
-        self.tell('AWGC:RMOD %s\n' % look_up[mode.upper()])
+        self.tell('AWGC:RMOD {0!s}\n'.format(look_up[mode.upper()]))
 
     # works
     def get_sequencer_mode(self, output_as_int=False):

--- a/hardware/fastcomtec/fastcomtecmcs6.py
+++ b/hardware/fastcomtec/fastcomtecmcs6.py
@@ -434,7 +434,7 @@ class FastComtec(Base, FastCounterInterface):
         #~ setting.fstchan = t/6.4
         #~ self.dll.StoreSettingData(ctypes.byref(setting), 0)
         #~ self.dll.NewSetting(0)
-        self.dll.RunCmd(0, 'DELAY=%f' % t)
+        self.dll.RunCmd(0, 'DELAY={0:f}'.format(t))
         return self.GetDelay()
 
     def GetDelay(self):
@@ -471,7 +471,7 @@ class FastComtec(Base, FastCounterInterface):
         fil = open(filename + '.asc', 'w')
         for i in laser_index:
             for n in data[i:i+int(round(3000/(0.1*2**self.GetBitshift())))+int(round(1000/(0.1*2**self.GetBitshift())))]:
-                fil.write('%s\n'%n)
+                fil.write('{0!s}\n'.format(n))
         fil.close()
 
     def SaveData(self, filename):
@@ -479,7 +479,7 @@ class FastComtec(Base, FastCounterInterface):
         data = self.get_data()
         fil = open(filename + '.asc', 'w')
         for n in data:
-            fil.write('%s\n'%n)
+            fil.write('{0!s}\n'.format(n))
         fil.close()
 
     def GetState(self):

--- a/hardware/fastcomtec/fastcomtecp7887.py
+++ b/hardware/fastcomtec/fastcomtecp7887.py
@@ -445,7 +445,7 @@ class FastComtec(Base, FastCounterInterface):
         #~ setting.fstchan = t/6.4
         #~ self.dll.StoreSettingData(ctypes.byref(setting), 0)
         #~ self.dll.NewSetting(0)
-        self.dll.RunCmd(0, 'DELAY=%f' % t)
+        self.dll.RunCmd(0, 'DELAY={0:f}'.format(t))
         return self.GetDelay()
 
     def GetDelay(self):
@@ -482,7 +482,7 @@ class FastComtec(Base, FastCounterInterface):
         fil = open(filename + '.asc', 'w')
         for i in laser_index:
             for n in data[i:i+int(round(3000/(0.25*2**self.GetBitshift())))+int(round(1000/(0.25*2**self.GetBitshift())))]:
-                fil.write('%s\n'%n)
+                fil.write('{0!s}\n'.format(n))
         fil.close()
 
     def SaveData(self, filename):
@@ -490,7 +490,7 @@ class FastComtec(Base, FastCounterInterface):
         data = self.get_data()
         fil = open(filename + '.asc', 'w')
         for n in data:
-            fil.write('%s\n'%n)
+            fil.write('{0!s}\n'.format(n))
         fil.close()
 
     def GetState(self):

--- a/hardware/motor/motor_stage_pi.py
+++ b/hardware/motor/motor_stage_pi.py
@@ -385,7 +385,7 @@ class MotorStagePI(Base, MotorInterface):
         """
         constraints = self.get_constraints()
         axis_ID = constraints[axis]['ID']
-        self._serial_connection_xyz.write(axis_ID+'SP%s'%move)
+        self._serial_connection_xyz.write(axis_ID+'SP{0!s}'.format(move))
         self._serial_connection_xyz.write(axis_ID+'MP')
 
 
@@ -656,13 +656,13 @@ class MotorStagePI(Base, MotorInterface):
         try:
             if 'x' in param_dict:
                 vel = int(param_dict['x']*10000)
-                self._serial_connection_xyz.write(constraints['x']['ID']+'SV%i\n'%(vel))
+                self._serial_connection_xyz.write(constraints['x']['ID']+'SV{0:d}\n'.format((vel)))
             if 'y' in param_dict:
                 vel = int(param_dict['y']*10000)
-                self._serial_connection_xyz.write(constraints['y']['ID']+'SV%i\n'%(vel))
+                self._serial_connection_xyz.write(constraints['y']['ID']+'SV{0:d}\n'.format((vel)))
             if 'z' in param_dict:
                 vel = int(param_dict['z']*10000)
-                self._serial_connection_xyz.write(constraints['z']['ID']+'SV%i\n'%(vel))
+                self._serial_connection_xyz.write(constraints['z']['ID']+'SV{0:d}\n'.format((vel)))
             if 'phi' in param_dict:
                 vel = param_dict['phi']
                 data = self._speed_to_data_rot(vel)

--- a/logic/jupyterkernel/events.py
+++ b/logic/jupyterkernel/events.py
@@ -52,7 +52,7 @@ class EventManager():
           If ``event`` is not one of the known events.
         """
         if not callable(function):
-            raise TypeError('Need a callable, got %r' % function)
+            raise TypeError('Need a callable, got {0!r}'.format(function))
         self.callbacks[event].append(function)
     
     def unregister(self, event, function):

--- a/logic/jupyterkernel/helpers.py
+++ b/logic/jupyterkernel/helpers.py
@@ -187,7 +187,7 @@ def getfigs(*fig_nums):
         for num in fig_nums:
             f = Gcf.figs.get(num)
             if f is None:
-                print('Warning: figure %s not available.' % num)
+                print('Warning: figure {0!s} not available.'.format(num))
             else:
                 figs.append(f.canvas.figure)
         return figs

--- a/logic/jupyterkernel/stream.py
+++ b/logic/jupyterkernel/stream.py
@@ -38,7 +38,7 @@ class QZMQStream(QtCore.QObject):
         self.readnotifier = QtCore.QSocketNotifier(
             self.socket.get(zmq.FD),
             QtCore.QSocketNotifier.Read)
-        logging.debug( "Notifier: %s" % self.readnotifier.socket())
+        logging.debug( "Notifier: {0!s}".format(self.readnotifier.socket()))
         self.readnotifier.activated.connect(self.checkForMessage)
 
     def checkForMessage(self, socket):
@@ -46,14 +46,14 @@ class QZMQStream(QtCore.QObject):
 
           @param socket: ZMQ socket
         """
-        logging.debug( "Check: %s" % self.readnotifier.socket())
+        logging.debug( "Check: {0!s}".format(self.readnotifier.socket()))
         self.readnotifier.setEnabled(False)
         check = True
         try:
             while check:
                 events = self.socket.get(zmq.EVENTS)
                 check = events & zmq.POLLIN
-                logging.debug( "EVENTS: %s" % events)
+                logging.debug( "EVENTS: {0!s}".format(events))
                 if check:
                     try:
                         msg = self.socket.recv_multipart(zmq.NOBLOCK)
@@ -62,9 +62,9 @@ class QZMQStream(QtCore.QObject):
                             # state changed since poll event
                             pass
                         else:
-                            logging.info( "RECV Error: %s" % zmq.strerror(e.errno))
+                            logging.info( "RECV Error: {0!s}".format(zmq.strerror(e.errno)))
                     else:
-                        logging.debug( "MSG: %s %s" % (self.readnotifier.socket(), msg))
+                        logging.debug( "MSG: {0!s} {1!s}".format(self.readnotifier.socket(), msg))
                         self.sigMsgRecvd.emit(msg)
         except:
             pass

--- a/tools/pyqtgraphmod/SpinBox.py
+++ b/tools/pyqtgraphmod/SpinBox.py
@@ -269,7 +269,7 @@ class SpinBox(QtGui.QAbstractSpinBox):
                 #val = val.toDouble()[0]
             self.setValue(val)
         else:
-            print("Warning: SpinBox.setProperty('%s', ..) not supported." % prop)
+            print("Warning: SpinBox.setProperty('{0!s}', ..) not supported.".format(prop))
 
     def setSuffix(self, suf):
         self.setOpts(suffix=suf)
@@ -429,14 +429,14 @@ class SpinBox(QtGui.QAbstractSpinBox):
         if self.opts['siPrefix']:
             if self.val == 0 and prev is not None:
                 (s, p) = fn.siScale(prev)
-                txt = "0.0 %s%s" % (p, self.opts['suffix'])
+                txt = "0.0 {0!s}{1!s}".format(p, self.opts['suffix'])
             else:
                 txt = fn.siFormat(float(self.val),
                                   precision=self.opts['decimals']+1,
                                   suffix=self.opts['suffix']
                                   )
         else:
-            txt = '%.14g%s' % (self.val , self.opts['suffix'])
+            txt = '{0:.14g}{1!s}'.format(self.val , self.opts['suffix'])
         self.lineEdit().setText(txt)
         self.lastText = txt
         self.skipValidate = False


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:drogenlied:qudi?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:drogenlied:qudi?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
